### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/Paint-market/transactions.png?label=ready&title=Ready)](https://waffle.io/Paint-market/transactions)
 # transactions
 Transactions server for Paint Market


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/Paint-market/transactions

This was requested by a real person (user pietgeursen) on waffle.io, we're not trying to spam you.
